### PR TITLE
Initialize Expo React Native app with TypeScript, Zustand and Supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+EXPO_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+.expo/
+.expo-shared/
+web-build/
+dist/
+*.log
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+.env
+.env.*
+!.env.example

--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,17 @@
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { StatusBar } from 'expo-status-bar';
+import { PaperProvider } from 'react-native-paper';
+
+import { RootNavigator } from './src/navigation/RootNavigator';
+import { appTheme } from './src/theme/theme';
+
+export default function App() {
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <PaperProvider theme={appTheme}>
+        <StatusBar style="auto" />
+        <RootNavigator />
+      </PaperProvider>
+    </GestureHandlerRootView>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# commonhold
+# Commonhold mobile app
+
+Expo + React Native + TypeScript starter configured with:
+
+- Zustand for client state
+- Supabase (`@supabase/supabase-js`) for BaaS
+- React Navigation (native stack)
+- React Native Paper for UI components
+- Gesture handler, safe-area, screens, and reanimated primitives
+
+## Getting started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Add environment variables:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+3. Start Expo:
+
+   ```bash
+   npm run start
+   ```
+
+## Environment variables
+
+- `EXPO_PUBLIC_SUPABASE_URL`
+- `EXPO_PUBLIC_SUPABASE_ANON_KEY`
+
+These are read from `process.env` and exposed at build time by Expo.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,19 @@
+{
+  "expo": {
+    "name": "Commonhold",
+    "slug": "commonhold",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "automatic",
+    "assetBundlePatterns": [
+      "**/*"
+    ],
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {},
+    "web": {
+      "bundler": "metro"
+    }
+  }
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin'],
+  };
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+import 'react-native-gesture-handler';
+import 'react-native-reanimated';
+import { registerRootComponent } from 'expo';
+
+import App from './App';
+
+registerRootComponent(App);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "commonhold",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@expo/vector-icons": "^14.0.2",
+    "@react-navigation/native": "^6.1.18",
+    "@react-navigation/native-stack": "^6.11.0",
+    "@supabase/supabase-js": "^2.49.1",
+    "expo": "^51.0.28",
+    "expo-constants": "^16.0.2",
+    "expo-status-bar": "^1.12.1",
+    "react": "18.2.0",
+    "react-native": "0.74.5",
+    "react-native-gesture-handler": "^2.20.2",
+    "react-native-paper": "^5.12.5",
+    "react-native-reanimated": "^3.15.4",
+    "react-native-safe-area-context": "^4.11.0",
+    "react-native-screens": "^3.35.0",
+    "zustand": "^5.0.3"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.25.2",
+    "@types/react": "^18.3.5",
+    "typescript": "^5.6.2",
+    "babel-preset-expo": "^11.0.14"
+  }
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,21 @@
+import Constants from 'expo-constants';
+import { createClient } from '@supabase/supabase-js';
+
+const extra = Constants.expoConfig?.extra ?? {};
+
+export const supabaseUrl =
+  process.env.EXPO_PUBLIC_SUPABASE_URL ?? (extra.supabaseUrl as string | undefined) ?? '';
+export const supabaseAnonKey =
+  process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? (extra.supabaseAnonKey as string | undefined) ?? '';
+
+export const hasSupabaseCredentials = Boolean(supabaseUrl && supabaseAnonKey);
+
+export const supabase = hasSupabaseCredentials
+  ? createClient(supabaseUrl, supabaseAnonKey, {
+      auth: {
+        autoRefreshToken: true,
+        persistSession: true,
+        detectSessionInUrl: false,
+      },
+    })
+  : null;

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,0 +1,20 @@
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import { HomeScreen } from '../screens/HomeScreen';
+
+export type RootStackParamList = {
+  Home: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export function RootNavigator() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={HomeScreen} options={{ title: 'Commonhold' }} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,0 +1,57 @@
+import { SafeAreaView, StyleSheet, View } from 'react-native';
+import { Button, Card, Text } from 'react-native-paper';
+
+import { hasSupabaseCredentials } from '../lib/supabase';
+import { useAppStore } from '../store/useAppStore';
+
+export function HomeScreen() {
+  const isAuthenticated = useAppStore((state) => state.isAuthenticated);
+  const setAuthenticated = useAppStore((state) => state.setAuthenticated);
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.container}>
+        <Text variant="headlineMedium">Commonhold</Text>
+        <Text variant="bodyMedium" style={styles.subtitle}>
+          Expo + React Native + TypeScript + Zustand starter with Supabase.
+        </Text>
+
+        <Card style={styles.card}>
+          <Card.Content>
+            <Text variant="titleMedium">Backend status</Text>
+            <Text variant="bodyMedium" style={styles.body}>
+              {hasSupabaseCredentials
+                ? 'Supabase keys detected. Ready to connect.'
+                : 'Add EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY to start using Supabase.'}
+            </Text>
+          </Card.Content>
+        </Card>
+
+        <Button mode="contained" onPress={() => setAuthenticated(!isAuthenticated)}>
+          {isAuthenticated ? 'Sign out (demo state)' : 'Sign in (demo state)'}
+        </Button>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    gap: 16,
+  },
+  subtitle: {
+    opacity: 0.75,
+  },
+  card: {
+    marginVertical: 8,
+  },
+  body: {
+    marginTop: 8,
+  },
+});

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+type AppState = {
+  isAuthenticated: boolean;
+  setAuthenticated: (value: boolean) => void;
+};
+
+export const useAppStore = create<AppState>((set) => ({
+  isAuthenticated: false,
+  setAuthenticated: (value) => set({ isAuthenticated: value }),
+}));

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,0 +1,10 @@
+import { MD3LightTheme } from 'react-native-paper';
+
+export const appTheme = {
+  ...MD3LightTheme,
+  colors: {
+    ...MD3LightTheme.colors,
+    primary: '#1f8c4c',
+    secondary: '#4d7f5f',
+  },
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    ".expo/types/**/*.ts"
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a ready-to-run Expo + React Native + TypeScript starter for the Commonhold mobile app.
- Use Supabase as the backend-as-a-service and `zustand` for lightweight client state management.
- Ship basic UI/navigation foundations so development can start immediately with sensible defaults.

### Description
- Add core project scaffolding and runtime configuration including `package.json` (Expo, React Navigation, React Native Paper, Reanimated, Supabase, `zustand`), `app.json`, `babel.config.js` (with Reanimated plugin), `tsconfig.json`, `index.js`, and `App.tsx`.
- Implement Supabase bootstrap at `src/lib/supabase.ts` that reads `EXPO_PUBLIC_SUPABASE_URL` and `EXPO_PUBLIC_SUPABASE_ANON_KEY` and exports `hasSupabaseCredentials` and `supabase` (null when creds are missing).
- Add app wiring: a small Zustand store in `src/store/useAppStore.ts`, theme in `src/theme/theme.ts`, navigation in `src/navigation/RootNavigator.tsx`, and a starter `src/screens/HomeScreen.tsx` which displays Supabase readiness and a demo auth toggle.
- Add developer conveniences: `README.md` with getting-started instructions, `.env.example`, and `.gitignore`.

### Testing
- Attempted scaffolding with `npx create-expo-app` but it failed due to registry access (`403 Forbidden`).
- Attempted dependency installation with `npm install` but it failed due to registry access (`403 Forbidden`).
- Validated critical JSON/config files parse successfully using `node -e` to parse `package.json` and `app.json`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69963f09ccf8833297d5d460151ae343)