### PR TITLE
Add Supabase auth flow: publishable key, auth screens, and session state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
-EXPO_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
-EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+EXPO_PUBLIC_SUPABASE_URL=https://ccrrfcjaugvwteohmmsd.supabase.co
+EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_AxEoXGAof25blJY8P0NdbQ_fWKxzyXq
+# Backward-compatible fallback if older code expects anon key variable:
+EXPO_PUBLIC_SUPABASE_ANON_KEY=

--- a/README.md
+++ b/README.md
@@ -28,9 +28,19 @@ Expo + React Native + TypeScript starter configured with:
    npm run start
    ```
 
+## User management flow (Supabase Auth)
+
+The app follows the Expo + Supabase auth flow:
+
+- Restores the existing auth session on app launch.
+- Shows an email/password sign-in and sign-up screen when signed out.
+- Listens for auth state changes and routes users to the authenticated home screen.
+- Displays basic profile info for the active user and supports sign out.
+
 ## Environment variables
 
 - `EXPO_PUBLIC_SUPABASE_URL`
-- `EXPO_PUBLIC_SUPABASE_ANON_KEY`
+- `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY`
+- `EXPO_PUBLIC_SUPABASE_ANON_KEY` (optional fallback for older setups)
 
-These are read from `process.env` and exposed at build time by Expo.
+The app prefers the publishable key and falls back to anon key for compatibility.

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -5,13 +5,20 @@ const extra = Constants.expoConfig?.extra ?? {};
 
 export const supabaseUrl =
   process.env.EXPO_PUBLIC_SUPABASE_URL ?? (extra.supabaseUrl as string | undefined) ?? '';
-export const supabaseAnonKey =
-  process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? (extra.supabaseAnonKey as string | undefined) ?? '';
 
-export const hasSupabaseCredentials = Boolean(supabaseUrl && supabaseAnonKey);
+const publishableKeyFromEnv =
+  process.env.EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY ??
+  (extra.supabasePublishableKey as string | undefined) ??
+  '';
+
+const anonKeyFromEnv = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? (extra.supabaseAnonKey as string | undefined) ?? '';
+
+export const supabasePublishableKey = publishableKeyFromEnv || anonKeyFromEnv;
+
+export const hasSupabaseCredentials = Boolean(supabaseUrl && supabasePublishableKey);
 
 export const supabase = hasSupabaseCredentials
-  ? createClient(supabaseUrl, supabaseAnonKey, {
+  ? createClient(supabaseUrl, supabasePublishableKey, {
       auth: {
         autoRefreshToken: true,
         persistSession: true,

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -1,19 +1,68 @@
+import { useEffect } from 'react';
+import { ActivityIndicator, View } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
+import { supabase } from '../lib/supabase';
+import { AuthScreen } from '../screens/AuthScreen';
 import { HomeScreen } from '../screens/HomeScreen';
+import { useAppStore } from '../store/useAppStore';
 
 export type RootStackParamList = {
+  Auth: undefined;
   Home: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
+function LoadingScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <ActivityIndicator size="large" />
+    </View>
+  );
+}
+
 export function RootNavigator() {
+  const session = useAppStore((state) => state.session);
+  const isLoadingSession = useAppStore((state) => state.isLoadingSession);
+  const setSession = useAppStore((state) => state.setSession);
+  const setIsLoadingSession = useAppStore((state) => state.setIsLoadingSession);
+
+  useEffect(() => {
+    if (!supabase) {
+      setIsLoadingSession(false);
+      return;
+    }
+
+    supabase.auth.getSession().then(({ data: { session: currentSession } }) => {
+      setSession(currentSession);
+      setIsLoadingSession(false);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, currentSession) => {
+      setSession(currentSession);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [setIsLoadingSession, setSession]);
+
+  if (isLoadingSession) {
+    return <LoadingScreen />;
+  }
+
   return (
     <NavigationContainer>
       <Stack.Navigator>
-        <Stack.Screen name="Home" component={HomeScreen} options={{ title: 'Commonhold' }} />
+        {session ? (
+          <Stack.Screen name="Home" component={HomeScreen} options={{ title: 'Commonhold' }} />
+        ) : (
+          <Stack.Screen name="Auth" component={AuthScreen} options={{ title: 'Sign in' }} />
+        )}
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/screens/AuthScreen.tsx
+++ b/src/screens/AuthScreen.tsx
@@ -1,0 +1,138 @@
+import { useMemo, useState } from 'react';
+import { KeyboardAvoidingView, Platform, SafeAreaView, StyleSheet, View } from 'react-native';
+import { Button, Card, Text, TextInput } from 'react-native-paper';
+
+import { hasSupabaseCredentials, supabase } from '../lib/supabase';
+
+export function AuthScreen() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isBusy, setIsBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const trimmedEmail = useMemo(() => email.trim(), [email]);
+  const canSubmit = trimmedEmail.length > 0 && password.length >= 6 && !isBusy && hasSupabaseCredentials;
+
+  const signInWithEmail = async () => {
+    if (!supabase) {
+      setMessage('Supabase credentials are missing. Add them to your environment.');
+      return;
+    }
+
+    setIsBusy(true);
+    setMessage(null);
+
+    const { error } = await supabase.auth.signInWithPassword({ email: trimmedEmail, password });
+
+    setIsBusy(false);
+    setMessage(error ? error.message : null);
+  };
+
+  const signUpWithEmail = async () => {
+    if (!supabase) {
+      setMessage('Supabase credentials are missing. Add them to your environment.');
+      return;
+    }
+
+    setIsBusy(true);
+    setMessage(null);
+
+    const { error } = await supabase.auth.signUp({
+      email: trimmedEmail,
+      password,
+    });
+
+    setIsBusy(false);
+    if (error) {
+      setMessage(error.message);
+      return;
+    }
+
+    setMessage('Check your email for the confirmation link to complete sign up.');
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        style={styles.keyboardAvoidingView}
+        behavior={Platform.select({ ios: 'padding', android: undefined })}
+      >
+        <View style={styles.container}>
+          <Text variant="headlineMedium">Commonhold</Text>
+          <Text variant="bodyMedium" style={styles.subtitle}>
+            Sign in to manage properties, tenants, and maintenance requests.
+          </Text>
+
+          <Card>
+            <Card.Content style={styles.cardContent}>
+              <TextInput
+                label="Email"
+                value={email}
+                onChangeText={setEmail}
+                autoCapitalize="none"
+                keyboardType="email-address"
+                textContentType="emailAddress"
+                autoComplete="email"
+              />
+
+              <TextInput
+                label="Password"
+                value={password}
+                onChangeText={setPassword}
+                secureTextEntry
+                textContentType="password"
+                autoComplete="password"
+              />
+
+              <Button mode="contained" onPress={signInWithEmail} disabled={!canSubmit} loading={isBusy}>
+                Sign in
+              </Button>
+
+              <Button mode="outlined" onPress={signUpWithEmail} disabled={!canSubmit} loading={isBusy}>
+                Create account
+              </Button>
+
+              {message ? <Text style={styles.message}>{message}</Text> : null}
+              {!hasSupabaseCredentials ? (
+                <Text style={styles.warning}>
+                  Add EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY to enable auth.
+                </Text>
+              ) : null}
+              {password.length > 0 && password.length < 6 ? (
+                <Text style={styles.warning}>Password must be at least 6 characters.</Text>
+              ) : null}
+            </Card.Content>
+          </Card>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+  },
+  keyboardAvoidingView: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    gap: 16,
+  },
+  subtitle: {
+    opacity: 0.75,
+  },
+  cardContent: {
+    gap: 12,
+  },
+  message: {
+    marginTop: 4,
+  },
+  warning: {
+    color: '#b00020',
+    marginTop: 4,
+  },
+});

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,34 +1,38 @@
 import { SafeAreaView, StyleSheet, View } from 'react-native';
 import { Button, Card, Text } from 'react-native-paper';
 
-import { hasSupabaseCredentials } from '../lib/supabase';
+import { supabase } from '../lib/supabase';
 import { useAppStore } from '../store/useAppStore';
 
 export function HomeScreen() {
-  const isAuthenticated = useAppStore((state) => state.isAuthenticated);
-  const setAuthenticated = useAppStore((state) => state.setAuthenticated);
+  const user = useAppStore((state) => state.user);
+
+  const signOut = async () => {
+    if (!supabase) {
+      return;
+    }
+
+    await supabase.auth.signOut();
+  };
 
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.container}>
-        <Text variant="headlineMedium">Commonhold</Text>
+        <Text variant="headlineMedium">Welcome to Commonhold</Text>
         <Text variant="bodyMedium" style={styles.subtitle}>
-          Expo + React Native + TypeScript + Zustand starter with Supabase.
+          You are signed in and ready to manage your portfolio.
         </Text>
 
-        <Card style={styles.card}>
-          <Card.Content>
-            <Text variant="titleMedium">Backend status</Text>
-            <Text variant="bodyMedium" style={styles.body}>
-              {hasSupabaseCredentials
-                ? 'Supabase keys detected. Ready to connect.'
-                : 'Add EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY to start using Supabase.'}
-            </Text>
+        <Card>
+          <Card.Content style={styles.cardContent}>
+            <Text variant="titleMedium">Profile</Text>
+            <Text variant="bodyMedium">Email: {user?.email ?? 'Unknown'}</Text>
+            <Text variant="bodySmall">User ID: {user?.id ?? 'Unknown'}</Text>
           </Card.Content>
         </Card>
 
-        <Button mode="contained" onPress={() => setAuthenticated(!isAuthenticated)}>
-          {isAuthenticated ? 'Sign out (demo state)' : 'Sign in (demo state)'}
+        <Button mode="contained-tonal" onPress={signOut}>
+          Sign out
         </Button>
       </View>
     </SafeAreaView>
@@ -48,10 +52,7 @@ const styles = StyleSheet.create({
   subtitle: {
     opacity: 0.75,
   },
-  card: {
-    marginVertical: 8,
-  },
-  body: {
-    marginTop: 8,
+  cardContent: {
+    gap: 8,
   },
 });

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -1,11 +1,18 @@
+import type { Session, User } from '@supabase/supabase-js';
 import { create } from 'zustand';
 
 type AppState = {
-  isAuthenticated: boolean;
-  setAuthenticated: (value: boolean) => void;
+  isLoadingSession: boolean;
+  session: Session | null;
+  user: User | null;
+  setSession: (session: Session | null) => void;
+  setIsLoadingSession: (value: boolean) => void;
 };
 
 export const useAppStore = create<AppState>((set) => ({
-  isAuthenticated: false,
-  setAuthenticated: (value) => set({ isAuthenticated: value }),
+  isLoadingSession: true,
+  session: null,
+  user: null,
+  setSession: (session) => set({ session, user: session?.user ?? null }),
+  setIsLoadingSession: (value) => set({ isLoadingSession: value }),
 }));


### PR DESCRIPTION
### Motivation

- Introduce a full Supabase auth flow so users can sign up, sign in, and maintain sessions instead of demo state toggles.
- Prefer the new Supabase publishable key while keeping backward-compatible support for the legacy anon key variable.

### Description

- Updated `.env.example` to include `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY` and keep `EXPO_PUBLIC_SUPABASE_ANON_KEY` as an optional fallback.
- Updated `src/lib/supabase.ts` to prefer `EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY`, expose `supabasePublishableKey`, and create the Supabase client using the preferred key while keeping credential presence checks.
- Added a persistent auth flow: `src/store/useAppStore.ts` now tracks `isLoadingSession`, `session`, and `user` with setters; `RootNavigator` loads and listens for Supabase auth state changes and conditionally routes to `Auth` or `Home` and shows a loading UI while resolving the session.
- Implemented `AuthScreen` to support email/password sign-in and sign-up with validation and user-facing messages, and updated `HomeScreen` to display profile info and perform real sign-out.
- Updated `README.md` to document the user management flow.

### Testing

- Performed a TypeScript type-check (`tsc --noEmit`) to verify type consistency, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4c07c73608332ab884578fb4b2073)